### PR TITLE
fixed getAddress method (was missing @arduinoobjectmethod)

### DIFF
--- a/nanpy/dallastemperature.py
+++ b/nanpy/dallastemperature.py
@@ -22,6 +22,7 @@ class DallasTemperature(ArduinoObject):
     def getDeviceCount(self):
         pass
 
+    @arduinoobjectmethod
     def getAddress(self, index):
         val = self.call('getAddress')
         if val == "1":


### PR DESCRIPTION
Missing @arduinoobjectmethod prevents nanpy from sending the request parameter to nanpy-firmware..

With this fix you can now get device address by index.

```
from nanpy import DallasTemperature
sensors = DallasTemperature(10)
sensors.getAddress(x)
```
