### PR TITLE
Make git clone actually work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ PyPi <https://pypi.python.org/pypi/nanpy>`__.
 
 ::
 
-    git clone git@github.com:nanpy/nanpy-firmware.git
+    git clone https://github.com/nanpy/nanpy-firmware.git
     cd nanpy-firmware
     ./configure.sh
 


### PR DESCRIPTION
Otherwise got this error:
    Cloning into 'nanpy-firmware'...
    Permission denied (publickey).
    fatal: Could not read from remote repository.