### PR TITLE
MCP41xxx addition

### DIFF
--- a/nanpy/MCP41xxx.py
+++ b/nanpy/MCP41xxx.py
@@ -1,0 +1,14 @@
+from nanpy.arduinoboard import ArduinoObject
+from nanpy.arduinoboard import (arduinoobjectmethod, returns)
+
+class MCP41xxx(ArduinoObject):
+
+    def __init__(self, dac, connection=None):
+        ArduinoObject.__init__(self, connection=connection)
+        self.id = self.call('new', dac)
+
+
+    @arduinoobjectmethod
+    def analogWrite(self, gate, value):
+        pass
+


### PR DESCRIPTION
Added MCP41xxx.py file for MCP41xxx library support to control MCP41xxx digital potentiometers.

