### PR TITLE
Added attach method in servo class with documentation.

### DIFF
--- a/nanpy/servo.py
+++ b/nanpy/servo.py
@@ -1,6 +1,7 @@
 from nanpy.arduinoboard import ArduinoObject
 from nanpy.arduinoboard import (arduinoobjectmethod, returns)
 
+
 class Servo(ArduinoObject):
     cfg_h_name = 'USE_Servo'
 
@@ -24,6 +25,20 @@ class Servo(ArduinoObject):
     @returns(int)
     @arduinoobjectmethod
     def readMicroseconds(self, value):
+        pass
+
+    @arduinoobjectmethod
+    def attach(self, value):
+        """
+        The servo is attached by default.
+        Use this method only if you have
+        detached it previously.
+
+        Parameters
+        ___________
+        value: int
+            the pin to attach the servo to.
+        """
         pass
 
     @arduinoobjectmethod


### PR DESCRIPTION
In one of my projects I needed to use servos for a limited amount of time, however the system had to stay up constantly. Sometimes after using the servo it would continue making buzzing noises and draw electricity. The detach method solves this nicely, but Once detached you have to create a new servo object to use it again. As the Arduino board is limited to 12 servo objects at a time I would quickly run out of memory and had to restart the board manually. Being able to detach and attach servos however solves this problem nicely.  As there was already a detach method the attach method was missing. I have also made changes to the firmware to include the attach() method. 