### PR TITLE
Add macOS serial glob.

### DIFF
--- a/nanpy/serialmanager.py
+++ b/nanpy/serialmanager.py
@@ -18,6 +18,7 @@ class SerialManagerError(Exception):
 def _auto_detect_serial_unix(preferred_list=None):
     import glob
     glist = glob.glob('/dev/ttyACM*') + glob.glob('/dev/ttyUSB*')
+    glist += glob.glob('/dev/cu.usbmodem*')   # Arduino on macOS
     glist += ['/dev/ttyS0', '/dev/ttyS1']
     ret = []
 


### PR DESCRIPTION
On macOS, USB-over-serial devices show up at places like `/dev/cu.usbmodem123456`.